### PR TITLE
Support SQLAlchemy v2

### DIFF
--- a/lib/ingres_sa_dialect/base.py
+++ b/lib/ingres_sa_dialect/base.py
@@ -32,6 +32,7 @@ from sqlalchemy.schema import DDLElement
 from sqlalchemy.sql import compiler
 from sqlalchemy.sql.expression import func
 
+sqlalchemy_version_tuple = tuple(map(int, sqlalchemy.__version__.split('.')))
 
 # https://docs.actian.com/actianx/11.1/index.html#page/SQLRef/TRANSACTION_ISOLATION_LEVEL.htm
 isolation_lookup = set(
@@ -273,7 +274,7 @@ class IngresDialect(default.DefaultDialect):
     _isolation_lookup = isolation_lookup
     # TODO get_isolation_level()
     # TODO _check_max_identifier_length()
-    
+
     def __init__(self, **kwargs):
         default.DefaultDialect.__init__(self, **kwargs)
 
@@ -690,7 +691,7 @@ class IngresDialect(default.DefaultDialect):
     def get_default_schema_name(self, connection):
         rs = None
         try:
-            if (int((sqlalchemy.__version__).split('.')[0]) >= 2):
+            if (sqlalchemy_version_tuple >= (2,0)):
                 rs = connection.execute(func.dbmsinfo('username'))
             else:
                 sqltext = """SELECT dbmsinfo('username')"""

--- a/lib/ingres_sa_dialect/ingresdbi.py
+++ b/lib/ingres_sa_dialect/ingresdbi.py
@@ -7,9 +7,9 @@
 Ingres DB connector for the ingresdbi module, which can be downloaded from
 http://esd.ingres.com.
 """
-from ingres_sa_dialect.base import IngresDialect
-import sqlalchemy
 from sqlalchemy.engine.default import DefaultExecutionContext
+from ingres_sa_dialect.base import IngresDialect
+from ingres_sa_dialect.base import sqlalchemy_version_tuple
 
 class Ingres_ingresdbi(IngresDialect):
     driver = 'ingresdbi'
@@ -18,7 +18,7 @@ class Ingres_ingresdbi(IngresDialect):
     def __init__(self, **kwargs):
         IngresDialect.__init__(self, **kwargs)
 
-    if (int((sqlalchemy.__version__).split('.')[0]) >= 2):
+    if (sqlalchemy_version_tuple >= (2,0)):
         @classmethod
         def import_dbapi(cls):
             return __import__('ingresdbi')

--- a/lib/ingres_sa_dialect/ingresdbi.py
+++ b/lib/ingres_sa_dialect/ingresdbi.py
@@ -8,6 +8,7 @@ Ingres DB connector for the ingresdbi module, which can be downloaded from
 http://esd.ingres.com.
 """
 from ingres_sa_dialect.base import IngresDialect
+import sqlalchemy
 from sqlalchemy.engine.default import DefaultExecutionContext
 
 class Ingres_ingresdbi(IngresDialect):
@@ -17,9 +18,14 @@ class Ingres_ingresdbi(IngresDialect):
     def __init__(self, **kwargs):
         IngresDialect.__init__(self, **kwargs)
 
-    @classmethod
-    def dbapi(cls):
-        return __import__('ingresdbi')
+    if (int((sqlalchemy.__version__).split('.')[0]) >= 2):
+        @classmethod
+        def import_dbapi(cls):
+            return __import__('ingresdbi')
+    else:
+        @classmethod
+        def dbapi(cls):
+            return __import__('ingresdbi')
 
     def create_connect_args(self, url):
         opts = url.translate_connect_args(username='uid', password='pwd', host='vnode')

--- a/lib/ingres_sa_dialect/pyodbc.py
+++ b/lib/ingres_sa_dialect/pyodbc.py
@@ -8,9 +8,8 @@ Ingres DB connector for the pyodbc/pypyodbc module
 """
 
 import os
-
+import sqlalchemy
 from sqlalchemy.engine.default import DefaultExecutionContext
-
 from ingres_sa_dialect.base import IngresDialect
 
 
@@ -28,15 +27,26 @@ class Ingres_pyodbc(IngresDialect):
     def __init__(self, **kwargs):
         IngresDialect.__init__(self, **kwargs)
 
-    @classmethod
-    def dbapi(cls):
-        try:
-            driver = __import__(Ingres_pyodbc.driver)
-        except ModuleNotFoundError:
-            # fallback to pure Python version
-            Ingres_pyodbc.driver = 'pypyodbc'
-            driver = __import__(Ingres_pyodbc.driver)
-        return driver
+    if (int((sqlalchemy.__version__).split('.')[0]) >= 2):
+        @classmethod
+        def import_dbapi(cls):
+            try:
+                driver = __import__(Ingres_pyodbc.driver)
+            except ModuleNotFoundError:
+                # fallback to pure Python version
+                Ingres_pyodbc.driver = 'pypyodbc'
+                driver = __import__(Ingres_pyodbc.driver)
+            return driver
+    else:
+        @classmethod
+        def dbapi(cls):
+            try:
+                driver = __import__(Ingres_pyodbc.driver)
+            except ModuleNotFoundError:
+                # fallback to pure Python version
+                Ingres_pyodbc.driver = 'pypyodbc'
+                driver = __import__(Ingres_pyodbc.driver)
+            return driver
 
     def create_connect_args(self, url):
         opts = url.translate_connect_args(username='uid', password='pwd', host='vnode')

--- a/lib/ingres_sa_dialect/pyodbc.py
+++ b/lib/ingres_sa_dialect/pyodbc.py
@@ -8,10 +8,9 @@ Ingres DB connector for the pyodbc/pypyodbc module
 """
 
 import os
-import sqlalchemy
 from sqlalchemy.engine.default import DefaultExecutionContext
 from ingres_sa_dialect.base import IngresDialect
-
+from ingres_sa_dialect.base import sqlalchemy_version_tuple
 
 try:
     ModuleNotFoundError  # Python 3 sanity check
@@ -27,7 +26,7 @@ class Ingres_pyodbc(IngresDialect):
     def __init__(self, **kwargs):
         IngresDialect.__init__(self, **kwargs)
 
-    if (int((sqlalchemy.__version__).split('.')[0]) >= 2):
+    if (sqlalchemy_version_tuple >= (2,0)):
         @classmethod
         def import_dbapi(cls):
             try:

--- a/setup.py
+++ b/setup.py
@@ -11,8 +11,10 @@ setup(
     packages=find_packages('lib'),
     package_dir={'':'lib'},
 
-    entry_points="""
-    [sqlalchemy.dialects]
-    ingres = ingres_sa_dialect:base.dialect
-    """
+      entry_points = {                                                
+          'sqlalchemy.dialects': [                                    
+              'ingres = ingres_sa_dialect:base.dialect',              
+              'ingres.pyodbc = ingres_sa_dialect.pyodbc:Ingres_pyodbc'
+           ]                                                           
+      }                                                               
 )


### PR DESCRIPTION
**Purpose:** Support SQLAlchemy version 2 and maintain backward compatibility with SQLalchemy version 1.

**Testing:** Tested with SQLAlchemy releases [1.4.46](https://github.com/sqlalchemy/sqlalchemy/releases/tag/rel_1_4_46) and [2.0.3](https://github.com/sqlalchemy/sqlalchemy/releases/tag/rel_2_0_3).

**Reference Issue:** https://github.com/ActianCorp/ingres_sa_dialect/issues/5

**Useful Details:**  See [documentation](https://docs.sqlalchemy.org/en/20/core/internals.html#sqlalchemy.engine.default.DefaultDialect.import_dbapi) and [code comment](https://github.com/zzzeek/sqlalchemy/blob/main/lib/sqlalchemy/engine/create.py#L591) for information about migration from `Dialect.dbapi()` to `Dialect.import_dbapi()`.