### PR TITLE
Ingres dialect drop - Changes to params type and SQL execution calls

### DIFF
--- a/lib/ingres_sa_dialect/base.py
+++ b/lib/ingres_sa_dialect/base.py
@@ -293,12 +293,12 @@ class IngresDialect(default.DefaultDialect):
                 iicolumns
             WHERE
                 table_name = ?"""
-        params = [self.denormalize_name(table_name)]
+        params = (self.denormalize_name(table_name),)
         
         if schema:
             sqltext += """
                 AND table_owner = ?"""
-            params.append(self.denormalize_name(schema))
+            params = (*params, self.denormalize_name(schema))
             
         sqltext += """
             ORDER BY
@@ -307,7 +307,7 @@ class IngresDialect(default.DefaultDialect):
         rs = None
         columns = []
         try:
-            rs = connection.execute(sqltext, params)
+            rs = connection.exec_driver_sql(sqltext, params)
             
             for row in rs.fetchall():
                 coldata = {}
@@ -365,17 +365,17 @@ class IngresDialect(default.DefaultDialect):
                 k.constraint_name = c.constraint_name
             AND c.constraint_type = 'P'
             AND k.table_name = ?"""
-        params = [self.denormalize_name(table_name)]
+        params = (self.denormalize_name(table_name),)
         
         if schema:
             sqltext += """
                 AND k.schema_name = ?"""
-            params.append(self.denormalize_name(schema))
+            params = (*params, self.denormalize_name(schema))
         
         rs = None
         
         try:
-            rs = connection.execute(sqltext, params)
+            rs = connection.exec_driver_sql(sqltext, params)
             
             return [row[0].rstrip() for row in rs.fetchall()]
         finally:
@@ -407,12 +407,12 @@ class IngresDialect(default.DefaultDialect):
             AND f.constraint_name = rc.ref_constraint_name
             AND p.key_position = f.key_position
             AND f.table_name = ?"""
-        params = [self.denormalize_name(table_name)]
+        params = (self.denormalize_name(table_name),)
         
         if schema:
             sqltext += """
                 AND f.schema_name = ?"""
-            params.append(self.denormalize_name(schema))
+            params = (*params, self.denormalize_name(schema))
             
         sqltext += """
             ORDER BY 
@@ -421,7 +421,7 @@ class IngresDialect(default.DefaultDialect):
         rs = None
         foreign_keys = {}
         try:
-            rs = connection.execute(sqltext, params)
+            rs = connection.exec_driver_sql(sqltext, params)
             
             for row in rs.fetchall():
                 name = row[0].rstrip()
@@ -468,7 +468,7 @@ class IngresDialect(default.DefaultDialect):
         if schema:
             sqltext += """
                 AND table_owner = ?"""
-            params = [self.denormalize_name(schema)]
+            params = (self.denormalize_name(schema),)
             
             if schema != "$ingres":
                 sqltext += " AND table_name NOT LIKE 'ii%'"
@@ -481,10 +481,10 @@ class IngresDialect(default.DefaultDialect):
         
         try:
             if params:
-                rs = connection.execute(sqltext, params)
+                rs = connection.exec_driver_sql(sqltext, params)
             else:
                 # sqlalchemy assumes anything after query text is a list/tuple of values
-                rs = connection.execute(sqltext)
+                rs = connection.exec_driver_sql(sqltext)
         
             return [row[0].rstrip() for row in rs.fetchall()]
         finally:
@@ -502,7 +502,7 @@ class IngresDialect(default.DefaultDialect):
         rs = None
         
         try:
-            rs = connection.execute(sqltext)
+            rs = connection.exec_driver_sql(sqltext)
             
             return [row[0].rstrip() for row in rs.fetchall()]
         finally:
@@ -650,16 +650,16 @@ class IngresDialect(default.DefaultDialect):
             WHERE
                 table_name = ?
             AND table_type = 'T'"""
-        params = [self.denormalize_name(table_name)]
+        params = (self.denormalize_name(table_name),)
         
         if schema:
             sqltext += """
                 AND table_owner = ?"""
-            params.append(self.denormalize_name(schema))
+            params = (*params, self.denormalize_name(schema))
 
         rs = None
         try:
-            rs = connection.execute(sqltext, params)
+            rs = connection.exec_driver_sql(sqltext, params)
             return len(rs.fetchall()) > 0
         finally:
             if rs:
@@ -673,17 +673,17 @@ class IngresDialect(default.DefaultDialect):
                 iisequences
             WHERE
                 seq_name = ?"""
-        params = [self.denormalize_name(sequence_name)]
+        params = (self.denormalize_name(sequence_name),)
         
         if schema:
             sqltext += """
                 AND seq_owner = ?"""
-            params.append(self.denormalize_name(schema))
+            params = (*params, self.denormalize_name(schema))
             
         rs = None
         
         try:
-            rs = connection.execute(sqltext, params)
+            rs = connection.exec_driver_sql(sqltext, params)
             return len(rs.fetchall()) > 0
         finally:
             if rs:

--- a/lib/ingres_sa_dialect/base.py
+++ b/lib/ingres_sa_dialect/base.py
@@ -525,7 +525,7 @@ class IngresDialect(default.DefaultDialect):
             sqltext += """
                 WHERE
                     table_owner = ?"""
-            params = [self.denormalize_name(schema)]
+            params = (self.denormalize_name(schema),)
         else:
             sqltext += """
                 WHERE 
@@ -535,9 +535,9 @@ class IngresDialect(default.DefaultDialect):
         
         try:
             if params:
-                rs = connection.execute(sqltext, params)
+                rs = connection.exec_driver_sql(sqltext, params)
             else:
-                rs = connection.execute(sqltext)
+                rs = connection.exec_driver_sql(sqltext)
             
             return [row[0].rstrip() for row in rs.fetchall()]
         finally:
@@ -553,12 +553,12 @@ class IngresDialect(default.DefaultDialect):
                 iiviews
             WHERE
                 table_name = ?"""
-        params = [self.denormalize_name(view_name)]
+        params = (self.denormalize_name(view_name),)
         
         if schema:
             sqltext += """
                 AND table_owner = ?"""
-            params.append(self.denormalize_name(schema))
+            params(*params, self.denormalize_name(schema))
         else:
             sqltext += """
                 AND table_owner != '$ingres'"""
@@ -570,7 +570,7 @@ class IngresDialect(default.DefaultDialect):
         rs = None
         
         try:
-            rs = connection.execute(sqltext, params)
+            rs = connection.exec_driver_sql(sqltext, params)
             
             return "".join([row[0] for row in rs.fetchall()])
         finally:
@@ -591,12 +591,12 @@ class IngresDialect(default.DefaultDialect):
                 i.index_name = c.index_name
             AND i.index_owner = c.index_owner
             AND i.base_name = ?"""
-        params = [self.denormalize_name(table_name)]
+        params = (self.denormalize_name(table_name),)
         
         if schema:
             sqltext += """
                 AND i.index_owner = ?"""
-            params.append(self.denormalize_name(schema))
+            params(*params, self.denormalize_name(schema))
             
         sqltext += """
             ORDER BY
@@ -606,7 +606,7 @@ class IngresDialect(default.DefaultDialect):
         indexes = {}
         
         try:
-            rs = connection.execute(sqltext, params)
+            rs = connection.exec_driver_sql(sqltext, params)
             
             for row in rs.fetchall():
                 name = row[0].rstrip()

--- a/setup.py
+++ b/setup.py
@@ -3,10 +3,10 @@ setup(
     name = "ingres_sa_dialect",
     version = "0.4",
     author = "Chris Clark",
-    author-email = "Chris.Clark@actian.com",
+    author_email = "Chris.Clark@actian.com",
     description = "An Ingres dialect for SQLAlchemy",
     maintainer = "Michael Habiger",
-    maintainer-email = "michael.habiger@hcl-software.com",
+    maintainer_email = "michael.habiger@hcl-software.com",
 
     license = "MIT",
 

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,12 @@
 from setuptools import setup, find_packages
 setup(
     name = "ingres_sa_dialect",
-    version = "0.3",
+    version = "0.4",
     author = "Chris Clark",
-    author_email = "Chris.Clark@actian.com",
+    author-email = "Chris.Clark@actian.com",
     description = "An Ingres dialect for SQLAlchemy",
+    maintainer = "Michael Habiger",
+    maintainer-email = "michael.habiger@hcl-software.com",
 
     license = "MIT",
 


### PR DESCRIPTION
### Configuration
MS Windows 10
SQLAlchemy 2.0.25 (released Jan 3, 2024)
Ingres Dialect 0.3 (cloned Jan 12)
Ingres 11.2.0 build 15807

### Test Execution Command
`pytest --db ingres_odbc --maxfail=15000 --ignore=test\dialect test`

### Results with the Ingres Dialect for SQLAlchemy
Test Case Run Results | Default | With Modifications
--|--|--
Passed | 7865 | 12332
Failed | 670 | 1981
Skipped | 1822 | 1922
Errors | 9727 | 2222
Warnings | 6 | 5
Execution Time | 211.40s (0:03:31) | 1111.54s (0:18:31)

### Details
The change from using Python lists to Python tuples for holding SQL parameter values was to alleviate the following error, which commonly occurred with test cases that used ORM style coding (versus literal SQL strings) for executing SQL statements.  

`sqlalchemy.exc.ArgumentError: List argument must consist only of tuples or dictionaries`

### Note about Parameter Style for SQL Statements
The type of [parameter markers](https://peps.python.org/pep-0249/#paramstyle) used in the SQL statements for the SQLAlchemy Ingres dialect was left as "question mark" style, since in comparing other SQLAlchemy dialects, such as the ones for [Sqlite](https://github.com/sqlalchemy/sqlalchemy/tree/main/lib/sqlalchemy/dialects/sqlite) and [Postgres](https://github.com/sqlalchemy/sqlalchemy/tree/main/lib/sqlalchemy/dialects/postgresql), there are a number of different parameter marker styles used, with the question mark style being very common.

### SQLAlchemy Connection.exec_driver_sql versus Connection.execute

See [link](https://docs.sqlalchemy.org/en/20/core/connections.html) for SQLAlchemy documentation on the Engine.Connection object, which has these methods for executing SQL statements:
 - exec_driver_sql
 - execute

The SQLAlchemy dialects for other vendors seemed to mostly use `exec_driver_sql` over `execute` for executing SQL statements on Connection objects.

SQLAlchemy issue [4848](https://github.com/sqlalchemy/sqlalchemy/issues/4848) contains some discussion from the SQLAlchemy architect(s) on using `execute` vs `exec_driver_sql`.